### PR TITLE
CSP report-to enabled in Chrome 70

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1111,7 +1111,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "70"
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
In September 2018, the Content Security Policy `report-to` directive was put behind the Reporting API feature flag (https://bugs.chromium.org/p/chromium/issues/detail?id=726634#c18), and the `Report-To` header was then enabled in Chrome 70 for Intervention and Deprecation reports (https://developers.google.com/web/updates/2018/10/nic70#more, https://www.chromestatus.com/feature/5544632075157504), which also enabled it for CSP.

I tested sending/receiving CSP reports via `report-to` in Chrome 71.